### PR TITLE
Add constructors from LDrawPolygon to subclass LDrawRectangle

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/draw/LDrawRectangle.java
+++ b/src/main/java/org/vaadin/addon/leaflet/draw/LDrawRectangle.java
@@ -7,4 +7,12 @@ package org.vaadin.addon.leaflet.draw;
  */
 public class LDrawRectangle extends LDrawPolygon {
 
+  public LDrawRectangle(LMap map) {
+    super(map);
+  }
+
+  public LDrawRectangle() {
+    super();
+  }
+
 }


### PR DESCRIPTION
Constructors are not inherited in Java. Because of this, calling `new LDrawPolygon(map);` was possible while `new LDrawRectangle(map);` was not possible. This change fixes that by adding the constructors from `LDrawPolygon` to the subclass `LDrawRectangle`.
