### PR TITLE
Added missing import to LDrawRectangle

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/draw/LDrawRectangle.java
+++ b/src/main/java/org/vaadin/addon/leaflet/draw/LDrawRectangle.java
@@ -1,5 +1,6 @@
 package org.vaadin.addon.leaflet.draw;
 
+import org.vaadin.addon.leaflet.LMap;
 
 /**
  * Extension to initiate drawing of a rectangular Polygon on a map.


### PR DESCRIPTION
The change that added the constructors was missing an import statement to LMap.
